### PR TITLE
Whitelist Hotfix 2 - Support for no account on first login

### DIFF
--- a/app/assets/js/scripts/uibinder.js
+++ b/app/assets/js/scripts/uibinder.js
@@ -72,7 +72,8 @@ function showMainUI(data){
         $('#main').show()
 
         const isLoggedIn = Object.keys(ConfigManager.getAuthAccounts()).length > 0
-        const isWhitelisted = ( ConfigManager.getWhitelistStatus() !== null && // status exists
+        const isWhitelisted = ( isLoggedIn &&
+                                ConfigManager.getWhitelistStatus() !== null && // status exists
                                 ConfigManager.getWhitelistStatus().status === 0 && // not banned
                                 ConfigManager.getWhitelistStatus().uuid.replace(/-/g, "") === ConfigManager.getSelectedAccount().uuid.replace(/-/g, "")) // uuids match
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "helioslauncher",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helioslauncher",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "productName": "Helios Launcher",
   "description": "Modded Minecraft Launcher",
   "author": "Daniel Scalzi (https://github.com/dscalzi/)",


### PR DESCRIPTION
Before the whitelist was trying to check uuids but mistakenly forgot to verify an account existed.