### PR TITLE
Move MoonLauncher Data to own App Data File

### DIFF
--- a/app/assets/js/configmanager.js
+++ b/app/assets/js/configmanager.js
@@ -6,7 +6,7 @@ const logger = require('./loggerutil')('%c[ConfigManager]', 'color: #a02d2a; fon
 
 const sysRoot = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Application Support' : process.env.HOME)
 // TODO change
-const dataPath = path.join(sysRoot, '.westeroscraft')
+const dataPath = path.join(sysRoot, '.mooncraft')
 
 // Forked processes do not have access to electron, so we have this workaround.
 const launcherDir = process.env.CONFIG_DIRECT_PATH || require('electron').remote.app.getPath('userData')


### PR DESCRIPTION
Moving the add data file from that used in the fork to ".mooncraft"